### PR TITLE
Reorganize `disorder function` hierarchy

### DIFF
--- a/src/ontology/idpo-edit.owl
+++ b/src/ontology/idpo-edit.owl
@@ -7,7 +7,7 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      ontologyIRI="http://purl.obolibrary.org/obo/idpo.owl"
      versionIRI="http://purl.obolibrary.org/obo/idpo/releases/2025-06-01/idpo.owl">
-    <Prefix name="" IRI="http://www.w3.org/2002/07/owl#"/>
+    <Prefix name="" IRI="http://purl.obolibrary.org/obo/idpo.owl/"/>
     <Prefix name="owl" IRI="http://www.w3.org/2002/07/owl#"/>
     <Prefix name="rdf" IRI="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
     <Prefix name="xml" IRI="http://www.w3.org/XML/1998/namespace"/>
@@ -49,6 +49,9 @@
         <AnnotationProperty abbreviatedIRI="owl:versionInfo"/>
         <Literal>Release 2025-06-01</Literal>
     </Annotation>
+    <Declaration>
+        <Class IRI="http://purl.obolibrary.org/obo/BFO_0000015"/>
+    </Declaration>
     <Declaration>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00000"/>
     </Declaration>
@@ -168,6 +171,9 @@
     </Declaration>
     <Declaration>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00512"/>
+    </Declaration>
+    <Declaration>
+        <Class IRI="http://purl.obolibrary.org/obo/SO_0001412"/>
     </Declaration>
     <Declaration>
         <ObjectProperty IRI="http://purl.obolibrary.org/obo/IDPO_00513"/>
@@ -222,6 +228,10 @@
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00000"/>
     </SubClassOf>
     <SubClassOf>
+        <Class IRI="http://purl.obolibrary.org/obo/IDPO_00024"/>
+        <Class IRI="http://purl.obolibrary.org/obo/SO_0001412"/>
+    </SubClassOf>
+    <SubClassOf>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00025"/>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00024"/>
     </SubClassOf>
@@ -498,6 +508,10 @@
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00000"/>
     </SubClassOf>
     <SubClassOf>
+        <Class IRI="http://purl.obolibrary.org/obo/IDPO_00501"/>
+        <Class IRI="http://purl.obolibrary.org/obo/SO_0001412"/>
+    </SubClassOf>
+    <SubClassOf>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00502"/>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00501"/>
     </SubClassOf>
@@ -524,6 +538,10 @@
     <SubClassOf>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00508"/>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00511"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="http://purl.obolibrary.org/obo/IDPO_00511"/>
+        <Class IRI="http://purl.obolibrary.org/obo/BFO_0000015"/>
     </SubClassOf>
     <SubClassOf>
         <Class IRI="http://purl.obolibrary.org/obo/IDPO_00511"/>
@@ -569,6 +587,11 @@
         </ObjectPropertyChain>
         <ObjectProperty IRI="http://purl.obolibrary.org/obo/IDPO_00514"/>
     </SubObjectPropertyOf>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://purl.obolibrary.org/obo/BFO_0000015</IRI>
+        <Literal>process</Literal>
+    </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
         <IRI>http://purl.obolibrary.org/obo/IAO_0000115</IRI>
@@ -1408,6 +1431,11 @@
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
         <IRI>http://purl.obolibrary.org/obo/RO_0002234</IRI>
         <Literal>has output</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>http://purl.obolibrary.org/obo/SO_0001412</IRI>
+        <Literal>topologically_defined_region</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>


### PR DESCRIPTION
There are three children of `disorder function`:

1. `entropic chain`
2. `molecular recognition site`
3. `self-interaction`

By the name of `disorder function` I was expecting these to be something like GO's molecular functions. However, I think there's a lot of variety in here that might need to be resolved.

1. `entropic chain` and `molecular recognition site` both seem to be terms about the regions on the protein sequence themselves. Therefore, I think classifying them under a Sequence Ontology (SO) term like [SO:0001412 (topologically defined region)](http://purl.obolibrary.org/obo/SO_0001412) might make more sense
2. `self-interaction` is more like a molecular function or biological process. I would also want to ask the GO people how they would suggest re-organizing this

I guess the follow-up question is, how are you annotating proteins this way? Maybe the sense is not correct here and we just need to relabel these terms. Like, rather than labeling `molecular recognition site`, it would be something like `disorder-induced positive regulation of the molecular recognition` or `disorder-induced increased flexibility of C-terminal tail`. how does this sound?

---

This PR already has some of the changes described here, but will need input to get the rest of the way.