### PR TITLE
Restructure process branch: rename transition terms and update definitions

### DIFF
--- a/src/ontology/idpo-edit.owl
+++ b/src/ontology/idpo-edit.owl
@@ -139,13 +139,13 @@ AnnotationAssertion(rdfs:label <http://www.geneontology.org/formats/oboInOwl#has
 # Object Property: <http://purl.obolibrary.org/obo/IDPO_0000087> (has final state)
 
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000087> "has final state")
-ObjectPropertyDomain(<http://purl.obolibrary.org/obo/IDPO_0000087> <http://purl.obolibrary.org/obo/IDPO_0000080>)
+ObjectPropertyDomain(<http://purl.obolibrary.org/obo/IDPO_0000087> <http://purl.obolibrary.org/obo/BFO_0000015>)
 ObjectPropertyRange(<http://purl.obolibrary.org/obo/IDPO_0000087> <http://purl.obolibrary.org/obo/BFO_0000019>)
 
 # Object Property: <http://purl.obolibrary.org/obo/IDPO_0000088> (has initial state)
 
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000088> "has initial state")
-ObjectPropertyDomain(<http://purl.obolibrary.org/obo/IDPO_0000088> <http://purl.obolibrary.org/obo/IDPO_0000080>)
+ObjectPropertyDomain(<http://purl.obolibrary.org/obo/IDPO_0000088> <http://purl.obolibrary.org/obo/BFO_0000015>)
 ObjectPropertyRange(<http://purl.obolibrary.org/obo/IDPO_0000088> <http://purl.obolibrary.org/obo/BFO_0000019>)
 
 
@@ -259,7 +259,7 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynony
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000010> "transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000010> "IDPO:0000010")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000010> "structural transition")
-SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000010> <http://purl.obolibrary.org/obo/IDPO_0000080>)
+SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000010> <http://purl.obolibrary.org/obo/BFO_0000015>)
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000011> (disorder to order)
 
@@ -779,8 +779,8 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000067> <http://purl.obolibrary
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000075> (condensate material state)
 
 AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:29602697") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000075> "A quality that describes the viscoelastic behavior and internal molecular organization of a condensate under given conditions, used to characterize proteins or protein regions that are part of the condensate.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000075> "physical state")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000075> "material state")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000075> "physical state")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000075> "condensate material state")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000075> "IDPO:0000075")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000075> "condensate material state")
@@ -826,13 +826,13 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000079> "solid-like condensate state")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000079> <http://purl.obolibrary.org/obo/IDPO_0000075>)
 
-# Class: <http://purl.obolibrary.org/obo/IDPO_0000080> (transition)
+# Class: <http://purl.obolibrary.org/obo/IDPO_0000080> (DEPRECATED transition)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000080> "A temporally extended process in which a protein or protein region changes from one state to another, under specific conditions.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000080> "transition")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000080> "IDPO:0000080")
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000080> "transition")
-SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000080> <http://purl.obolibrary.org/obo/BFO_0000015>)
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/IDPO_0000080> "Obsolete due to semantic ambiguity and excessive generality.")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000080> "DEPRECATED transition")
+AnnotationAssertion(rdfs:seeAlso <http://purl.obolibrary.org/obo/IDPO_0000080> <http://purl.obolibrary.org/obo/IDPO_0000010>)
+AnnotationAssertion(rdfs:seeAlso <http://purl.obolibrary.org/obo/IDPO_0000080> <http://purl.obolibrary.org/obo/IDPO_0000083>)
+AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/IDPO_0000080> "true"^^xsd:boolean)
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000081> (transition to a more ordered state)
 
@@ -856,7 +856,7 @@ AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMI
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000083> "transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000083> "IDPO:0000083")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000083> "higher-order assembly transition")
-SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000083> <http://purl.obolibrary.org/obo/IDPO_0000080>)
+SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000083> <http://purl.obolibrary.org/obo/BFO_0000015>)
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000084> (biomolecular condensate formation)
 

--- a/src/ontology/idpo-edit.owl
+++ b/src/ontology/idpo-edit.owl
@@ -252,13 +252,14 @@ AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://pu
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000009> "likely disorder state")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000009> <http://purl.obolibrary.org/obo/IDPO_0000007>)
 
-# Class: <http://purl.obolibrary.org/obo/IDPO_0000010> (structural transition)
+# Class: <http://purl.obolibrary.org/obo/IDPO_0000010> (protein structural transition)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000010> "A dynamic process in which a protein region undergoes a reversible or irreversible transformation between defined structural states.")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000010> "conformational transition")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000010> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000010> "structural transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000010> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000010> "IDPO:0000010")
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000010> "structural transition")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000010> "protein structural transition")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000010> <http://purl.obolibrary.org/obo/BFO_0000015>)
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000011> (disorder to order)
@@ -266,7 +267,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000010> <http://purl.obolibrary
 AnnotationAssertion(Annotation(<http://purl.org/dc/elements/1.1/source> <https://disprot.org/DP04243r004>) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:38801244") <http://purl.obolibrary.org/obo/IAO_0000112> <http://purl.obolibrary.org/obo/IDPO_0000011> "Annotation DP04243r004")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000011> "A structural transition in which a protein region changes from a disordered state to a fully ordered, well-defined three-dimensional conformation.")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> <http://purl.obolibrary.org/obo/IDPO_0000011> "structural ordering")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000011> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000011> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000011> "IDPO:0000011")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000011> "disorder to order")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000011> <http://purl.obolibrary.org/obo/IDPO_0000081>)
@@ -277,7 +278,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000011> ObjectSomeValuesFrom(<h
 
 AnnotationAssertion(Annotation(<http://purl.org/dc/elements/1.1/source> <https://disprot.org/DP01511r002>) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:24356903") <http://purl.obolibrary.org/obo/IAO_0000112> <http://purl.obolibrary.org/obo/IDPO_0000012> "Annotation DP01511r002")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000012> "A structural transition in which a protein changes from a molten globule state to a fully ordered, well-defined three-dimensional conformation.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000012> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000012> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000012> "IDPO:0000012")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000012> "molten globule to order")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000012> <http://purl.obolibrary.org/obo/IDPO_0000081>)
@@ -288,7 +289,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000012> ObjectSomeValuesFrom(<h
 
 AnnotationAssertion(Annotation(<http://purl.org/dc/elements/1.1/source> <https://disprot.org/DP02342r013>) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:23462742") <http://purl.obolibrary.org/obo/IAO_0000112> <http://purl.obolibrary.org/obo/IDPO_0000013> "Annotation DP02342r013")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000013> "A structural transition in which a protein region changes from a pre-molten globule to a fully ordered, well-defined three-dimensional conformation.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000013> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000013> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000013> "IDPO:0000013")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000013> "pre-molten globule to order")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000013> <http://purl.obolibrary.org/obo/IDPO_0000081>)
@@ -300,7 +301,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000013> ObjectSomeValuesFrom(<h
 AnnotationAssertion(Annotation(<http://purl.org/dc/elements/1.1/source> <https://disprot.org/DP03670r005>) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:32817423") <http://purl.obolibrary.org/obo/IAO_0000112> <http://purl.obolibrary.org/obo/IDPO_0000014> "Annotation DP03670r005")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000014> "A structural transition in which a protein region changes from an ordered state to a fully disordered conformation, losing secondary and tertiary structure elements.")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym> <http://purl.obolibrary.org/obo/IDPO_0000014> "structural unfolding")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000014> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000014> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000014> "IDPO:0000014")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000014> "order to disorder")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000014> <http://purl.obolibrary.org/obo/IDPO_0000082>)
@@ -310,7 +311,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000014> ObjectSomeValuesFrom(<h
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000015> (order to molten globule)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000015> "A structural transition in which a protein region changes from an ordered state to a molten globule state, losing specific tertiary interactions while retaining native-like secondary structure.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000015> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000015> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000015> "IDPO:0000015")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000015> "order to molten globule")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000015> <http://purl.obolibrary.org/obo/IDPO_0000082>)
@@ -320,7 +321,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000015> ObjectSomeValuesFrom(<h
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000016> (order to pre-molten globule)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000016> "A structural transition in which a protein region changes from an ordered state to a pre-molten globule state, losing stable tertiary and secondary interactions and retaining only residual secondary structure elements.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000016> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000016> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000016> "IDPO:0000016")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000016> "order to pre-molten globule")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000016> <http://purl.obolibrary.org/obo/IDPO_0000082>)
@@ -331,7 +332,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000016> ObjectSomeValuesFrom(<h
 
 AnnotationAssertion(Annotation(<http://purl.org/dc/elements/1.1/source> <https://disprot.org/DP00207r012>) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:29136196") <http://purl.obolibrary.org/obo/IAO_0000112> <http://purl.obolibrary.org/obo/IDPO_0000018> "Annotation DP00207r012")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000018> "A structural transition in which a protein region changes from a disordered state to a molten globule state, by gaining native-like secondary structure elements.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000018> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000018> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000018> "IDPO:0000018")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000018> "disorder to molten globule")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000018> <http://purl.obolibrary.org/obo/IDPO_0000081>)
@@ -342,7 +343,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000018> ObjectSomeValuesFrom(<h
 
 AnnotationAssertion(Annotation(<http://purl.org/dc/elements/1.1/source> <https://disprot.org/DP03773r003>) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:36037701") <http://purl.obolibrary.org/obo/IAO_0000112> <http://purl.obolibrary.org/obo/IDPO_0000019> "Annotation DP03773r003")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000019> "A structural transition in which a protein region changes from a disordered state to a pre-molten globule state, by gaining residual or transiently populated secondary structure elements.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000019> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000019> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000019> "IDPO:0000019")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000019> "disorder to pre-molten globule")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000019> <http://purl.obolibrary.org/obo/IDPO_0000081>)
@@ -352,7 +353,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000019> ObjectSomeValuesFrom(<h
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000020> (molten globule to disorder)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000020> "A structural transition in which a protein region changes from a molten globule state to a fully disordered state, losing all secondary structure elements.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000020> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000020> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000020> "IDPO:0000020")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000020> "molten globule to disorder")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000020> <http://purl.obolibrary.org/obo/IDPO_0000082>)
@@ -362,7 +363,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000020> ObjectSomeValuesFrom(<h
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000021> (molten globule to pre-molten globule)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000021> "A structural transition in which a protein region changes from a molten globule state to a pre-molten globule state, losing native-like secondary structure, maintaining only residual secondary structure elements.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000021> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000021> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000021> "IDPO:0000021")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000021> "molten globule to pre-molten globule")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000021> <http://purl.obolibrary.org/obo/IDPO_0000082>)
@@ -372,7 +373,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000021> ObjectSomeValuesFrom(<h
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000022> (pre-molten globule to disorder)
 
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000022> "A structural transition in which a protein region changes from a pre-molten globule state to a disordered state, losing residual or transiently populated secondary structure.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000022> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000022> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000022> "IDPO:0000022")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000022> "pre-molten globule to disorder")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000022> <http://purl.obolibrary.org/obo/IDPO_0000082>)
@@ -383,7 +384,7 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000022> ObjectSomeValuesFrom(<h
 
 AnnotationAssertion(Annotation(<http://purl.org/dc/elements/1.1/source> <https://disprot.org/DP00015r024>) Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:32338601") <http://purl.obolibrary.org/obo/IAO_0000112> <http://purl.obolibrary.org/obo/IDPO_0000023> "Annotation DP00015r024")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000023> "A structural transition in which a protein region changes from a pre-molten glouble state to a molten globule state, by gaining native-like secondary structure elements.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000023> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000023> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000023> "IDPO:0000023")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000023> "pre-molten globule to molten globule")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000023> <http://purl.obolibrary.org/obo/IDPO_0000081>)
@@ -392,12 +393,12 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000023> ObjectSomeValuesFrom(<h
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000025> (liquid-liquid phase separation)
 
-AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:29602697") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000025> "A demixing phenomenon driven by weak, transient multivalent interactions, resulting in two separate liquid phases, a dense phase and a dilute phase, that then stably coexist.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:29602697") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000025> "A biomolecular condensate formation involving a demixing driven by weak, transient multivalent interactions, resulting in two separate liquid phases, a dense phase and a dilute phase, that then stably coexist.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/IDPO_0000025> <https://orcid.org/0000-0001-8042-9939>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/IDPO_0000025> "PMID:38287572")
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasSynonymType> <http://purl.obolibrary.org/obo/OMO_0003000>) <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000025> "LLPS")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000025> "liquid–liquid demixing")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000025> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000025> "higher-order assembly transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000025> "IDPO:0000025")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000025> "liquid-liquid phase separation")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000025> <http://purl.obolibrary.org/obo/IDPO_0000084>)
@@ -406,12 +407,12 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000025> ObjectSomeValuesFrom(<h
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000026> (condensate ageing)
 
-AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:33510441") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000026> "A time-dependent process in which biomolecular condensates progressively transition from a dynamic, liquid-like state to less dynamic gel-like, glass-like, or solid-like states.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:33510441") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000026> "A higher-order assembly transition in which biomolecular condensates progressively transition from a dynamic, liquid-like state to less dynamic gel-like, glass-like, or solid-like states.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/IDPO_0000026> <https://orcid.org/0000-0001-8042-9939>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/IDPO_0000026> "PMID:29358076")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000026> "condensate hardening")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000026> "condensate maturation")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000026> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000026> "higher-order assembly transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000026> "IDPO:0000026")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000026> "condensate ageing")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000026> <http://purl.obolibrary.org/obo/IDPO_0000083>)
@@ -419,12 +420,12 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000026> ObjectSomeValuesFrom(<h
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000027> (gelation)
 
-AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:29602697") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000027> "A physical process by which a liquid-like condensate transitions into a viscoelastic, crosslinked gel-like state, driven by increased concentration or multivalent interactions.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:29602697") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000027> "A higher-order assembly transition by which a liquid-like condensate transitions into a viscoelastic, crosslinked gel-like state, driven by increased concentration or multivalent interactions.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/IDPO_0000027> <https://orcid.org/0000-0001-8042-9939>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/IDPO_0000027> "PMID:22579281")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000027> "liquid to gel transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/IDPO_0000027> "condensate gelation")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000027> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000027> "higher-order assembly transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000027> "IDPO:0000027")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000027> "gelation")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000027> <http://purl.obolibrary.org/obo/IDPO_0000083>)
@@ -433,11 +434,11 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000027> ObjectSomeValuesFrom(<h
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000028> (crystallization)
 
-AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:29602697") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000028> "A physical process through which a disordered liquid state transitions into a more ordered glass-like state, characterized by slow relaxation and arrested molecular motion.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:29602697") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000028> "A higher-order assembly transition through which a disordered liquid state transitions into a more ordered glass-like state, characterized by slow relaxation and arrested molecular motion.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/IDPO_0000028> <https://orcid.org/0000-0001-8042-9939>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000028> "liquid to glass transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym> <http://purl.obolibrary.org/obo/IDPO_0000028> "condensate crystallization")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000028> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000028> "higher-order assembly transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000028> "IDPO:0000028")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000028> "crystallization")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000028> <http://purl.obolibrary.org/obo/IDPO_0000083>)
@@ -755,23 +756,23 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000065> ObjectSomeValuesFrom(<h
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000066> (protein aggregate formation)
 
-AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:33510441") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000066> "Process involving a non-native state of a protein in which insoluble intermolecular interactions are established to form a higher-order irreversible assembly, usually as result of aberrant liquid-liquid phase separation.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:33510441") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000066> "A higher-order assembly transition involving a non-native state of a protein in which insoluble intermolecular interactions are established to form a higher-order irreversible assembly, usually as result of aberrant liquid-liquid phase separation.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/IDPO_0000066> <https://orcid.org/0000-0001-8042-9939>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/IDPO_0000066> "PMID:38825008")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000066> "aggregate assembly")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000066> "aggregate formation")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000066> "protein aggregation")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000066> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000066> "higher-order assembly transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000066> "IDPO:0000066")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000066> "protein aggregate formation")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000066> <http://purl.obolibrary.org/obo/IDPO_0000083>)
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000067> (amorphous aggregate formation)
 
-AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:40324497") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000067> "A process leading to the formation of a protein aggregate lacking stable or ordered structure.")
+AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:40324497") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000067> "A protein aggregate formation leading to the formation of a protein aggregate lacking stable or ordered structure.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/IDPO_0000067> <https://orcid.org/0000-0001-8042-9939>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> <http://purl.obolibrary.org/obo/IDPO_0000067> "PMID:26735904")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000067> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000067> "higher-order assembly transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000067> "IDPO:0000067")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000067> "amorphous aggregate formation")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000067> <http://purl.obolibrary.org/obo/IDPO_0000066>)
@@ -836,16 +837,16 @@ AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/IDPO_0000080>
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000081> (transition to a more ordered state)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000081> "A process in which a protein or protein region gains secondary and/or tertiary structure, leading to a more compacted or ordered conformation.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000081> "transition")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000081> "A protein structural transition in which a protein or protein region gains secondary and/or tertiary structure, leading to a more compacted or ordered conformation.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000081> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000081> "IDPO:0000081")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000081> "transition to a more ordered state")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000081> <http://purl.obolibrary.org/obo/IDPO_0000010>)
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000082> (transition to a more disordered state)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000082> "A process in which a protein or protein region losses secondary and/or tertiary structure, leading to a more extended or disordered conformation.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000082> "transition")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000082> "A protein structural transition in which a protein or protein region loses secondary and/or tertiary structure, leading to a more extended or disordered conformation.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000082> "protein structural transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000082> "IDPO:0000082")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000082> "transition to a more disordered state")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000082> <http://purl.obolibrary.org/obo/IDPO_0000010>)
@@ -853,16 +854,16 @@ SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000082> <http://purl.obolibrary
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000083> (higher-order assembly transition)
 
 AnnotationAssertion(Annotation(<http://purl.obolibrary.org/obo/IAO_0000119> "PMID:33510441") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000083> "A biophysical process in which a biomolecular condensate or aggregate is formed or undergoes a change in material state.")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000083> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000083> "higher-order assembly transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000083> "IDPO:0000083")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IDPO_0000083> "higher-order assembly transition")
 SubClassOf(<http://purl.obolibrary.org/obo/IDPO_0000083> <http://purl.obolibrary.org/obo/BFO_0000015>)
 
 # Class: <http://purl.obolibrary.org/obo/IDPO_0000084> (biomolecular condensate formation)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000084> "A membraneless assembly process that concentrates specific biomolecules through weak, multivalent interactions. It may exhibit a well-mixed or spatially organized internal structure and can dynamically transition between different material states.")
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/IDPO_0000084> "A higher-order assembly transition that concentrates specific biomolecules through weak, multivalent interactions. It may exhibit a well-mixed or spatially organized internal structure and can dynamically transition between different material states.")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/IDPO_0000084> "biological condensate assembly")
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000084> "transition")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/IDPO_0000084> "higher-order assembly transition")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/IDPO_0000084> "membraneless organelle assembly")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/IDPO_0000084> "non-membrane-bounded organelle assembly")
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#id> <http://purl.obolibrary.org/obo/IDPO_0000084> "IDPO:0000084")


### PR DESCRIPTION
Addresses points 8 and 9 (partial) of the review on https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2770.
Both reviewers flagged that transition (IDPO:0000080) is too broad as a label and the definition is protein-specific while the label is not.

- transition (IDPO:0000080) was deprecated due to semantic ambiguity and excessive generality.
- protein structural transition (IDPO:0000010) and higher-order assembly transition (IDPO:0000083) were placed as direct children of _BFO:process_.
- Process branch terms renamed to be self-explanatory.
- Process branch definitions transformed into Aristotelian form.
- has initial state (IDPO_0000088) and has final state (IDPO_0000087) range modified to _BFO:process_.